### PR TITLE
Fix empty popup in Chrome

### DIFF
--- a/src/js/polyfill.js
+++ b/src/js/polyfill.js
@@ -23,7 +23,7 @@ function generateBrowser() {
 
     let result = {};
     for (let name of definitions) {
-      result[name] = modifyFunction(original[name]);
+      result[name] = modifyFunction(original[name].bind(original));
     }
     return result;
   }


### PR DESCRIPTION
Fix #1
Ref.
https://github.com/KeithHenry/chromeExtensionAsync/issues/10
https://github.com/KeithHenry/chromeExtensionAsync/pull/13

## Another fix

Which fix do you like?

```diff
diff --git a/src/js/polyfill.js b/src/js/polyfill.js
index 4377236..f2bf59e 100644
--- a/src/js/polyfill.js
+++ b/src/js/polyfill.js
@@ -1,7 +1,7 @@
 
 
 function generateBrowser() {
-  function modifyFunction(f) {
+  function modifyFunction(f, self) {
     return (...args) => {
       return new Promise((resolve, reject) => {
         args.push(items => {
@@ -12,7 +12,7 @@ function generateBrowser() {
             resolve(items);
           }
         })
-        return f.apply(null, args);
+        return f.apply(self, args);
       });
     };
   }
@@ -23,7 +23,7 @@ function generateBrowser() {
 
     let result = {};
     for (let name of definitions) {
-      result[name] = modifyFunction(original[name]);
+      result[name] = modifyFunction(original[name], original);
     }
     return result;
   }
```